### PR TITLE
More visible yellow colors in white terminal.

### DIFF
--- a/themes/Ultimate White-color-theme.json
+++ b/themes/Ultimate White-color-theme.json
@@ -54,13 +54,13 @@
     "terminal.ansiBrightMagenta": "#A16A94",
     "terminal.ansiBrightRed": "#DB2D20",
     "terminal.ansiBrightWhite": "#ffffff",
-    "terminal.ansiBrightYellow": "#fff493",
+    "terminal.ansiBrightYellow": "#d6d300",
     "terminal.ansiCyan": "#29c9ff",
     "terminal.ansiGreen": "#01A252",
     "terminal.ansiMagenta": "#A16A94",
     "terminal.ansiRed": "#DB2D20",
     "terminal.ansiWhite": "#e9e9e9",
-    "terminal.ansiYellow": "#fcf81a"
+    "terminal.ansiYellow": "#a88900"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
When you type `npm start`, for instance, the word "npm" look too light and almost invisible. I don't know how to test extensions. Those colors are just suggestions.